### PR TITLE
Reinstate v1 docs

### DIFF
--- a/_docs/building-the-v1-chassis.md
+++ b/_docs/building-the-v1-chassis.md
@@ -1,0 +1,251 @@
+---
+title: Building the v1 Chassis
+summary: Here's how to build the chassis for the first version of Mirobot
+layout: doc
+tags:
+  - Building
+  - Chassis
+hardware: mirobot-v1
+type: instruction
+level: core
+---
+
+The parts
+-------------
+
+You should already have soldered together [the PCB](/docs/soldering-the-v1-pcb/). Now it's time to put the chassis together. The chassis is made out of the six panels shown below.
+
+![](/assets/docs/building-the-v1-chassis/01.jpg)
+
+To help you figure out which piece is which look for the dots (like a dice) on each panel that help identify them which we'll refer to in these instructions.
+
+![](/assets/docs/building-the-v1-chassis/02.jpg)
+
+You'll also need these parts that were left in the pink bag from the PCB build:
+
+![](/assets/docs/building-the-v1-chassis/03.jpg)
+
+The elastic bands that are used to hold the panels together can come in handy as spares.
+
+The only tool you will need for this assembly is a medium sized flat headed screwdriver.
+
+
+Step one
+-------------
+
+**Be careful with this step because the antenna mount is quite fragile**
+
+Find the antenna and the top antenna mount piece.
+
+![](/assets/docs/building-the-v1-chassis/04.jpg)
+
+Put the antenna cable through the hole first, then **gently** push the base of the antenna through the hole, twisting as you push it through.
+
+![](/assets/docs/building-the-v1-chassis/05.jpg)
+
+
+
+
+Once it is through the bracket, make sure it is rotated so the notch on the antenna aligns with the bracket.
+
+![](/assets/docs/building-the-v1-chassis/06.jpg)
+
+
+Step two
+-------------
+
+Put the two side pieces of the antenna mount into the base, making sure they are aligned as in the photo.
+
+![](/assets/docs/building-the-v1-chassis/07.jpg)
+
+
+Step three
+-------------
+
+Pull the cable out through the slot in the antenna (see photo) because we don't want it to go through the base, we want it to come out above the base
+
+![](/assets/docs/building-the-v1-chassis/08.jpg)
+
+Making sure the base is flat on the table, push the antenna into the hole and then pick it up and push it all the way through.
+
+Make sure that the top bracket fits into the side brackets.
+
+![](/assets/docs/building-the-v1-chassis/09.jpg)
+
+
+Step four
+-------------
+
+Find the left stepper motor bracket (on panel 4) and put the motor into it as shown in the picture. Make sure that the bracket goes through the two screw holes on the motor. Wind the cable once around it which will help keep the cable tidy but also helps to stop it falling out while you're building it. The cable should go through the bottom hole first, then loop around the motor and go through the top hole.
+Once you have done this, slot it into the left side piece (on panel 4) making sure that the blue part of the motor with the cables coming out of it points to the back of the robot like in this picture.
+
+![](/assets/docs/building-the-v1-chassis/10.jpg)
+
+
+Step five
+-------------
+
+Put the bulkhead (on panel 5) on to the chassis base (on panel 1) as shown.
+
+![](/assets/docs/building-the-v1-chassis/11.jpg)
+
+
+Step six
+-------------
+
+Gently slide the side of the robot on to the chassis base, taking care to align it with all of the pieces sticking through it. This can sometimes get snagged - don't force it on. If it's not going on easily, make sure that all of the pieces are properly aligned with the holes.
+
+![](/assets/docs/building-the-v1-chassis/12.jpg)
+
+
+Step seven
+-------------
+
+Snap off three of the small pegs and push them through the small holes against the side of the robot making sure that the flat side of the peg goes against the flat side of the robot. They should push through so that you can see the peg on either side of the hole. It is best to push the two bottom pegs in from the bottom up, otherwise they can push out when you pick up the robot. It can be helpful to use something hard to push them in to make sure they hold properly.
+
+![](/assets/docs/building-the-v1-chassis/13.jpg)
+
+
+Step eight
+-------------
+
+Slide the blue servo under the bulkhead on to the chassis base with its cable to the edge and then slot the two U shaped servo mounts (on panel 4) over the servo on either side of the plastic plates. They should slot into the holes on the base.
+
+![](/assets/docs/building-the-v1-chassis/14.jpg)
+
+
+Step nine
+-------------
+
+Place a stepper motor in the right side bracket (on panel 3) and put it into the right side piece (on panel 3) as shown. Wind the cable around in the same way as the first motor.
+
+![](/assets/docs/building-the-v1-chassis/15.jpg)
+
+
+Step ten
+-------------
+
+Slide the right side on to the base as you did on the other side, again taking care to make sure all of the parts are properly aligned. Do not force it on. If it is not sliding on easily, it just means something is not aligned.
+
+![](/assets/docs/building-the-v1-chassis/16.jpg)
+
+
+Step eleven
+-------------
+
+Snap off three more pegs and peg it on the same as you did for the other side.
+
+![](/assets/docs/building-the-v1-chassis/17.jpg)
+
+
+Step twelve
+-------------
+
+Put the main part of the robot to one side now and find the pieces for the pen arm (on panels 2, 3 and 4).
+
+Push the top pen mount through the pen arm as shown in the photo, making sure that it is facing the right way.
+
+![](/assets/docs/building-the-v1-chassis/18.jpg)
+
+
+Step thirteen
+-------------
+
+Push the long end of the adjustment plate (that has two holes in it) up through the hole in the pen mount as shown in the photo.
+
+![](/assets/docs/building-the-v1-chassis/19.jpg)
+
+
+Step fourteen
+-------------
+
+Push the second pen mount through the pen arm pointing in the same direction as the first and slide the adjustment plate down into the second pen mount that you just put in.
+
+![](/assets/docs/building-the-v1-chassis/20.jpg)
+
+
+Step fifteen
+-------------
+
+Place the two screws through the holes in the bracket and screw them both in by the same amount.
+
+These screws are used to adjust the pen so it is aligned with the centre of the wheels. If it's not properly aligned you'll get bumps at the corners of your lines when you draw.
+
+![](/assets/docs/building-the-v1-chassis/21.jpg)
+
+
+Step sixteen
+-------------
+
+Hook the elastic band through the holes ond around the small pegs on the other side. You can hook the elastic on to the pen mounts to keep it tight until you put a pen in place. Felt tips pens work the best!
+
+![](/assets/docs/building-the-v1-chassis/22.jpg)
+
+![](/assets/docs/building-the-v1-chassis/23.jpg)
+
+
+Step seventeen
+-------------
+
+Slide one end of the pen arm into the slots in the main chassis, with the pen mounts facing inwards towards the hole in the base. Drop the other end down into place so that it sits in nicely.
+
+![](/assets/docs/building-the-v1-chassis/24.jpg)
+
+
+Step eighteen
+-------------
+
+Clip both wheels (on panels 5 and 6) on to the metal part of the stepper motor, making sure to align them correctly. It should be a reasonably tight fit. It is best to squeeze together with your thumb on the back of the motor and your finger on the wheel as shown in this picture.
+
+![](/assets/docs/building-the-v1-chassis/25.jpg)
+
+
+Step nineteen
+-------------
+
+Slide the wheel covers (left wheel cover on panel 2 and right on panel 6) on to the tabs so that they cover the wheels then peg them on. There are two pieces like this and they will only go on one way with the logo facing the outside.
+
+![](/assets/docs/building-the-v1-chassis/26.jpg)
+
+
+Step twenty
+-------------
+
+Push the white plastic caster wheel through the hole in the back. Don't push directly on to the ball as this can damage it, push using the ridge around it.
+
+![](/assets/docs/building-the-v1-chassis/27.jpg)
+
+
+Step twenty-one
+-------------
+
+Turn the switch on the PCB to Off and insert batteries. Fit the PCB into the slot. It should go in upside down with the white stepper sockets at the bottom like in this picture.
+
+![](/assets/docs/building-the-v1-chassis/28.jpg)
+
+
+Step twenty-two
+-------------
+
+Connect both stepper motors. The plugs should only be able to go in one way.
+
+![](/assets/docs/building-the-v1-chassis/29.jpg)
+
+
+Step twenty-three
+-------------
+
+Connect the servo with the yellow cable at the right as marked on the PCB. Tuck the cable into the slots to keep it tidy as it passes along the chassis.
+
+![](/assets/docs/building-the-v1-chassis/30.jpg)
+
+
+Step twenty-four
+-------------
+
+Remove the WiFi module, click the small connector on the end of the antenna cable on to the small circular socket on the WiFi module and then put it back in to its socket.
+
+![](/assets/docs/building-the-v1-chassis/31.jpg)
+
+Well done! You're ready to [set up Mirobot](/docs/configure-wifi/), [get the pen in place](/docs/drawing-with-mirobot/) and [start drawing](/docs/drawing-shapes/). Don't forget to turn it on!
+

--- a/_docs/building-the-v1-chassis.md
+++ b/_docs/building-the-v1-chassis.md
@@ -8,6 +8,7 @@ tags:
 hardware: mirobot-v1
 type: instruction
 level: core
+frontpage: false
 ---
 
 The parts

--- a/_docs/configure-wifi.md
+++ b/_docs/configure-wifi.md
@@ -1,0 +1,38 @@
+---
+title: Configure the WiFi
+summary: Learn how to get your Mirobot on your network and configure the WiFi
+layout: doc
+tags:
+  - WiFi
+  - Setup
+  - Using
+hardware: mirobot-v1
+type: instruction
+level: core
+---
+
+Mirobot uses WiFi to communicate, which means the first thing you need to do to use it is to set up its WiFi connection. In this article there are a couple of WiFi networks that are being used:
+
+ - The internal WiFi network of the Mirobot. This appears as an access point that you can join your computer to. This is "Network A"
+ - Your existing WIFi network at home, school or work. In the second part of this we will be configuring Mirobot to join this network. This is "Network B". It can both have its own access point running and join your network at the same time.
+
+The first thing you'll need to do is to access the built-in web interface:
+
+ - Turn it on. The second red LED should start flashing and should then stay on
+ - Once it has stopped flashing you should be able to connect to the open wireless network called "mirobot" (Network A)
+ - Once you have connected to the "mirobot" WiFi access point, visit [http://10.10.100.254](http://10.10.100.254) and you should see the mirobot interface loading in your browser
+
+Get it on your network
+----------------------
+
+Once you've been able to use Mirobot via the built-in interface, the next step is to get it on your WiFi access point (Network B) so you can use the [apps](http://apps.mirobot.io):
+
+ - Make sure you are able to access the built-in interface on [http://10.10.100.254](http://10.10.100.254) as in the first step
+ - Click on the "Configure WiFi" link in the top right of the page
+   ![The configure WiFi link](/assets/docs/configure-wifi/1.png)
+ - Enter the details for your existing WiFi network (Network B). Click the scan button to find it and the encryption settings should be set automatically
+   ![The WiFi setup form](/assets/docs/configure-wifi/2.png)
+ - Click the "Save" button and Mirobot will restart
+ - After 20 seconds, reload your browser and it should say "WiFi Connected" instead
+ - To find out what its IP address is, you can click on the "WiFi Connected" link again and see it there
+ - Now you should join your computer to your existing network (Network A) again and access Mirobot via this IP address

--- a/_docs/configure-wifi.md
+++ b/_docs/configure-wifi.md
@@ -9,6 +9,7 @@ tags:
 hardware: mirobot-v1
 type: instruction
 level: core
+frontpage: false
 ---
 
 Mirobot uses WiFi to communicate, which means the first thing you need to do to use it is to set up its WiFi connection. In this article there are a couple of WiFi networks that are being used:

--- a/_docs/drawing-with-mirobot.md
+++ b/_docs/drawing-with-mirobot.md
@@ -1,0 +1,25 @@
+---
+title: Drawing with Mirobot
+summary: Some tips on how to get the best results from drawing with Mirobot
+layout: doc
+tags:
+  - Setup
+  - Using
+  - Drawing
+hardware:
+  - mirobot-v1
+  - mirobot-v2
+  - mirobot-v3
+type: instruction
+level: core
+---
+
+Put a pen in the pen arm and hold it in place with the elastic band. If you are using a v1 or v2 you should make sure that the pen arm screws are adjusted so that the tip of the pen is at the centre of the wheels, otherwise you will get bumps at the corners when you turn.
+
+When the arm is in the down position, the tip of the pen should be just a few mm below the wheel level. You can check this by putting the arm down and then looking across the wheels.
+
+![Drawing with Mirobot](/assets/docs/drawing-with-mirobot/1.jpg)
+
+Once the pen is in place, you can drag functions from the left hand side "Toolbox" into the "Program" section to make Mirobot move.
+
+Mirobot works best with a felt-tipped pen on a large piece of smooth paper. If the wheels are slipping when it is drawing it is because the pen is pushing down too hard and is dragging. Simply adjust the pen upwards slightly to stop this happening.

--- a/_docs/drawing-with-mirobot.md
+++ b/_docs/drawing-with-mirobot.md
@@ -8,10 +8,9 @@ tags:
   - Drawing
 hardware:
   - mirobot-v1
-  - mirobot-v2
-  - mirobot-v3
 type: instruction
 level: core
+frontpage: false
 ---
 
 Put a pen in the pen arm and hold it in place with the elastic band. If you are using a v1 or v2 you should make sure that the pen arm screws are adjusted so that the tip of the pen is at the centre of the wheels, otherwise you will get bumps at the corners when you turn.

--- a/_docs/soldering-the-v1-pcb.md
+++ b/_docs/soldering-the-v1-pcb.md
@@ -1,0 +1,137 @@
+---
+title: Soldering the v1 PCB
+summary: Follow these instructions to assemble the Mirobot control board
+layout: doc
+tags:
+  - Building
+  - PCB
+  - Soldering
+hardware: mirobot-v1
+type: instruction
+level: core
+---
+
+Unwrapping
+----------
+
+When you unwrap the package you should see a pink bag with the components in it, a white PCB and the black battery box.
+Take these out and put the rest of the package to one side for now.
+
+![Unwrapping](/assets/docs/soldering-the-v1-pcb/01.jpg)
+
+To assemble the PCB you will need:
+
+ - A soldering iron ([here's a good low cost one](http://www.amazon.co.uk/gp/product/B000ELJ0C4))
+ - Solder ([60/40 tin/lead solder](http://www.amazon.co.uk/gp/product/B00IMM9H3Y) is the easiest to use. Lead free is harder)
+
+It is highly recommended to watch [this soldering tutorial](https://learn.adafruit.com/adafruit-guide-excellent-soldering/) before starting if you're not used to soldering. Soldering isn't too difficult, but it's worth taking the time to make sure it's done well so it is more likely to work first time. 
+
+
+Soldering tips
+--------------
+
+ - Using 60/40 tin/lead solder really is much, much easier than using lead free. If it's your first time soldering, I wouldn't even try with lead free solder.
+ - Soldering is all about making the bond between the component and the PCB. After each component, make sure you can see a clear flow of solder between the two surfaces.
+ - If you can't see the two surfaces being fully connected, just heat it again and add a little solder and it should flow into place.
+ - Once you've soldered a pin, you shouldn't be able to see the hole it goes into because it should be fully covered by solder.
+ - Don't use too much solder as this can cause short circuiting.
+
+**WARNING: Soldering involves temperatures hot enough to melt metal, so please be careful and use appropriate safety wear**
+
+
+The parts
+-------------
+
+Here are all of the parts that you will need to use for this stage. There are some other parts in the pink bag that will be used at a later stage so put these away for now.
+
+![The parts](/assets/docs/soldering-the-v1-pcb/02.jpg)
+
+
+Step one
+-------------
+
+Solder the WiFi socket in place. Be careful not to use too much solder on this part because it can 'wick' up into the socket and make it hard to get the module in.
+
+![Step one](/assets/docs/soldering-the-v1-pcb/03.jpg)
+
+
+Step two
+-------------
+
+Solder both of the chip sockets in to place. Take care to put the notches on the short end in line with the outline on the PCB. The larger one should have the notch on the left and the smaller should have the notch on the right. Sometimes the pins on these get slightly bent so make sure they are all straight before putting them in.
+
+![Step two](/assets/docs/soldering-the-v1-pcb/04.jpg)
+
+
+Step three
+-------------
+
+Solder the stepper sockets in place. You need to make sure that the side with two notches in it is at the edge of the board - check the photo. They should clip satisfyingly into place.
+
+![Step three](/assets/docs/soldering-the-v1-pcb/05.jpg)
+
+
+Step four
+-------------
+
+Solder the expansion pins in to place. These should be inserted with the small end of the pins going through the PCB from the top down.
+
+![Step four](/assets/docs/soldering-the-v1-pcb/06.jpg)
+
+
+Step five
+-------------
+
+Solder in the power switch. This can go either way around.
+
+![Step five](/assets/docs/soldering-the-v1-pcb/07.jpg)
+
+
+Step six
+-------------
+
+Now we need to solder the pins on to the Arduino board we are using. The best way of doing this is to push both rows of pins into the Arduino socket as shown in this photo.
+Now is also a good time to put the stepper driver chip into its socket. You need to make sure the small notch on one end of the chip aligns with the notch on the socket. Check the photo if you're unsure.
+
+![Step six](/assets/docs/soldering-the-v1-pcb/08.jpg)
+
+You can then put the Arduino onto these pins and solder them in. Doing it this way makes sure they are well aligned and will fit in and out nice and easily. The pins are quite small but take your time and it shouldn't be too tricky.
+
+![Step six](/assets/docs/soldering-the-v1-pcb/09.jpg)
+
+
+Step seven
+-------------
+
+If you need to reprogram the Arduino at some point in the future, you can take it out of the socket and solder on the programming pins as shown in the photo. You don't need these on in order to use Mirobot though.
+
+![Step seven](/assets/docs/soldering-the-v1-pcb/13.jpg)
+
+
+Step eight
+-------------
+
+First, inspect your soldering. There should be no messy bits of solder bridging from the pins to other parts of the PCB. If there are, use the soldering iron to remove them. We're going to test the board before soldering the battery pack on because once it's in place it would need removing if there are any errors:
+
+![Step eight](/assets/docs/soldering-the-v1-pcb/10.jpg)
+
+ - Move the switch to the Off position.
+ - Put the Arduino and the WiFi module in to their sockets
+ - Put 4 AA batteries into the battery pack.
+ - Put the battery pack pins into the two remaining holes on the board, like in this photo
+ - Push gently on the bottom of the battery pack so it makes contact with the holes
+ - Move the switch to the On position.
+ - There should be two LEDs lit up on the Arduino. One should stay solid (the power LED) and one should flash for a few seconds before turning solid as well.
+
+If the LEDs don't turn on then turn it off straight away because there's most likely a short circuit. Take a careful look at the back of your board to double check for any bits of solder that might be bridging between pins.
+**Don't solder the battery pack on until you have successfully done this step!**
+It's worth making sure at this point that you're using fully charged batteries because low batteries can cause issues that may make this step fail.
+
+
+Step nine
+-------------
+
+![Step nine](/assets/docs/soldering-the-v1-pcb/11.jpg)
+
+It's time to attach the battery holder. First, peel off the cover over the sticky pad on the battery holder. Then push the pins on the holder through the PCB from behind like in this picture. Once you've pushed it on so it sticks then you should carefuly solder it.
+Put the batteries in the holder and turn the switch on again to make sure the LEDs still come on and flash correctly. If the LED starts flashing then the board is OK and you should start [building the chassis](/docs/building-the-v1-chassis/)

--- a/_docs/soldering-the-v1-pcb.md
+++ b/_docs/soldering-the-v1-pcb.md
@@ -9,6 +9,7 @@ tags:
 hardware: mirobot-v1
 type: instruction
 level: core
+frontpage: false
 ---
 
 Unwrapping

--- a/_docs/update-firmware-v1.md
+++ b/_docs/update-firmware-v1.md
@@ -9,6 +9,7 @@ tags:
 hardware: mirobot-v1
 type: instruction
 level: core
+frontpage: false
 ---
 
 Download the app

--- a/_docs/update-firmware-v1.md
+++ b/_docs/update-firmware-v1.md
@@ -1,0 +1,53 @@
+---
+title: Updating the firmware on v1
+summary: Use the updater to get the latest code running on Mirobot
+layout: doc
+tags:
+  - WiFi
+  - Firmware
+  - Updating
+hardware: mirobot-v1
+type: instruction
+level: core
+---
+
+Download the app
+----------------
+
+First, you'll need to download the updater application:
+
+ - [Mac Version](https://github.com/bjpirt/mirobot-updater/releases/download/v1.2.0/mirobot_updater_1.2.0_mac.zip)
+ - [Windows Version](https://github.com/bjpirt/mirobot-updater/releases/download/v1.2.0/mirobot_updater_1.2.0_win.zip)
+ - Linux Version ([32 bit](https://github.com/bjpirt/mirobot-updater/releases/download/v1.2.0/mirobot_updater_1.2.0_linux32.zip), [64 bit](https://github.com/bjpirt/mirobot-updater/releases/download/v1.2.0/mirobot_updater_1.2.0_linux64.zip)) - tested on Ubuntu
+
+Unzip the folder and run the application
+
+If you're on a mac you may need to right click on it and select "Open" if you're using a recent version of Mac OS X. See [this page](http://support.apple.com/en-gb/HT202491) for more details if you're interested why.
+
+
+Connect to Mirobot
+------------------
+
+You'll need to know Mirobot's IP address in order to update it. If you're on the mirobot network, its IP address will be 10.10.100.254.
+
+![The updater](/assets/docs/update-firmware-v1/firmware_update.png)
+
+If you're updating over the mirobot network, make sure you start the application while you have a connection to the internet so that it can download the latest versions.
+
+Enter the IP address and click connect. You should see the app update with the current versions (in green) or out of date versions (in red)
+
+
+Update
+------
+
+You can click the "Update" button next to the firmware you want to update. If the firmware looks up to date but didn't install properly you can still force update it to try again.
+
+
+Updating the Arduino firmware
+=============================
+It is no longer possible to update the Arduino firmware over the WiFi network because it has proven itself to have too great a risk of leaving it in a broken state. To update the Arduino firmware, you will need a USB to Serial converter compatible with the 6 pin header that's available on the Arduino. There are many different models of these converters, but I have found that those based on an FTDI chip are the best supported in general. Some examples of suitable converters are:
+
+ * [FTDI Friend](https://www.adafruit.com/products/284) from Adafruit. These are pretty well distributed so check if they're available locally
+ * [FTDI Cable](https://www.adafruit.com/products/70). Search locally for "TTL-232R-3V3" to find one of these closer to you
+
+If you're looking for a much cheaper option then you should search for "CP2102 USB Serial" on eBay to find a converter for a few dollars, though there are so many variants of these that it's difficult to recommend a specific one. Once you've got your converter, then you should follow [the instructions](../update-arduino-serial/) to update the firmware using the Arduino IDE over serial.

--- a/_docs/using-collision-detection-v1.md
+++ b/_docs/using-collision-detection-v1.md
@@ -8,6 +8,7 @@ tags:
 hardware: mirobot-v1
 type: instruction
 level: intermediate
+frontpage: false
 ---
 
 The parts

--- a/_docs/using-collision-detection-v1.md
+++ b/_docs/using-collision-detection-v1.md
@@ -1,0 +1,57 @@
+---
+title: Using Collision Detection on v1
+summary: Use this addon to get Mirobot bouncing off the walls
+layout: doc
+tags:
+  - Collision Detection
+  - Addons
+hardware: mirobot-v1
+type: instruction
+level: intermediate
+---
+
+The parts
+---------
+
+You'll need to find the parts below to build the collision detection addon:
+
+![The parts](/assets/docs/using-collision-detection-v1/01.jpg)
+
+Step one
+--------
+
+Solder the pin headers in place exactly as shown here. It's a good idea to lay out the PCBs with the tabs facing outwards like in this picture so you can make sure that the pins are in the correct slot. Although the PCBs are the same, they need different parts soldering on depending on which side they will be.
+
+![Step one](/assets/docs/using-collision-detection-v1/02.jpg)
+
+
+Step two
+--------
+
+Push the two lever switches into the PCB as shown here. The holes can be a little tight but use a little force to push them all the way through and solder them in. It's very important that the lever points in the direction of the narrow end of the PCB.
+
+![Step two](/assets/docs/using-collision-detection-v1/03.jpg)
+
+
+Step three
+----------
+
+Push the tabs on the PCBs into the slots on the front sides of the chassis as shown in the picture:
+
+![Step three](/assets/docs/using-collision-detection-v1/04.jpg)
+
+Once they are in position you should join the two PCBs together using the red and black cable. It doesn't matter which way round this cable goes.
+Now you should push the longer cable on to the four pins pointing upwards. Make sure to align the yellow wire with the side of the PCB marked GND.
+
+
+Step four
+---------
+
+Connect the other end of this long cable on to the main PCB in the position marked "bump", again making sure that the yellow wire is on the side marked GND (nearest the switch at the edge of the PCB).
+
+![Step four](/assets/docs/using-collision-detection-v1/05.jpg)
+
+Step five
+---------
+
+Now you can press the button in the web UI marked "Collision Detection" and watch as Mirobot detects collisions and reorients itself. You may need to [update](/docs/update-firmware-v1/) the UI firmware in order to do this.

--- a/_docs/using-line-following-v1.md
+++ b/_docs/using-line-following-v1.md
@@ -1,0 +1,102 @@
+---
+title: Using Line Following on v1
+summary: Use this addon to get Mirobot following lines
+layout: doc
+tags:
+  - Line Following
+  - Addons
+hardware: mirobot-v1
+type: instruction
+level: intermediate
+---
+
+First you'll need to solder the line following addon together, then you'll be able to start Mirobot following lines.
+
+The parts
+---------
+
+You'll need to find the parts below to build the line following addon:
+
+![The parts](/assets/docs/using-line-following-v1/01.jpg)
+
+The tools you'll need are:
+
+ - A soldering iron
+ - Solder (60/40 tin/lead solder is the easiest to use. Lead free is harder)
+ - Small wire cutters (snips)
+
+
+Step one
+--------
+
+Solder in the two resistors that are the same into positions R2 and R3. They should have stripes matching those in the picture; orange, orange, red, gold.
+
+![Step one](/assets/docs/using-line-following-v1/02.jpg)
+
+
+Step two
+--------
+
+Solder in the remaining resistor into position R1. It should have stripes matching those in the picture; orange, orange, black, gold.
+
+![Step two](/assets/docs/using-line-following-v1/03.jpg)
+
+Clip off all of the long resistor legs once you've soldered all of the resistors in.
+
+
+Step three
+----------
+
+The line follower uses infrared to detect the line, but because infrared light is invisible, it's difficult to know if you've got this part right or not so you'll need to take extra care over this step.
+
+The clear LED and the black receivers need soldering in. Look carefully at them and you will see that one side of their body is flat and that they have one long leg (on the opposite side). We will use these to make sure we get them in the right way round.
+
+![Step three](/assets/docs/using-line-following-v1/05.jpg)
+
+We'll also be soldering them on the opposite side to the resistors so the first thing to do is turn it over so you are looking at the side with no black lettering on it.
+
+Now you should put the clear LEDs on the end of the arms and the black receivers next to them, like in the photo. The flat side should be on the left and the long leg should be in the right hand hole.
+
+![Step three](/assets/docs/using-line-following-v1/04.jpg)
+
+Check again that they are all facing the right way, solder them in and clip off the legs.
+
+If you heat these LEDs too much they can break, so be careful to only use enough heat to melt the solder and not more
+
+
+Step four
+---------
+
+Solder the pin header in place on the top of the board. The short part of the pins should go through the hole and the long part should stick up (see the next photo if you're unsure)
+
+![Step four](/assets/docs/using-line-following-v1/07.jpg)
+
+
+Step five
+---------
+
+Now you've finished soldering, the line follower addon should look like this:
+
+![Step five](/assets/docs/using-line-following-v1/08.jpg)
+
+
+Step six
+--------
+
+Slide the line follower addon in to the slot at the front of Mirobot and push on the cable so the yellow wire is on the left (with the robot facing forward). Take a look at this photo if you are unsure:
+
+![Step six](/assets/docs/using-line-following-v1/09.jpg)
+
+
+Step seven
+----------
+
+Connect the other end of this long cable on to the main PCB in the position marked "line", making sure that the yellow wire is on the side marked GND (nearest the switch at the edge of the PCB).
+
+![Step seven](/assets/docs/using-line-following-v1/10.jpg)
+
+
+Step eight
+----------
+
+Draw a line approximately 1cm thick in a black pen on white paper, then press the button in the web UI marked "Line Following" and watch as Mirobot follows the line you have just drawn. You may need to [update](/docs/update-firmware-v1/) the UI firmware in order to do this.

--- a/_docs/using-line-following-v1.md
+++ b/_docs/using-line-following-v1.md
@@ -8,6 +8,7 @@ tags:
 hardware: mirobot-v1
 type: instruction
 level: intermediate
+frontpage: false
 ---
 
 First you'll need to solder the line following addon together, then you'll be able to start Mirobot following lines.

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@ title: Learn with Mime Industries
 layout: default
 ---
 
-{% capture tags %}{% for doc in site.docs %}{% for tag in doc.tags %}{{ tag }}|{% endfor %}{% endfor %}{% endcapture %}
+{% capture tags %}{% for doc in site.docs %}{% if doc.frontpage != false %}{% for tag in doc.tags %}{{ tag }}|{% endfor %}{% endif %}{% endfor %}{% endcapture %}
 {% assign taghash = tags | split:'|' | sort | tag_hash %}
-{% capture hws %}{% for doc in site.docs %}{% for hardware in doc.hardware %}{{ hardware }}|{% endfor %}{% endfor %}{% endcapture %}
+{% capture hws %}{% for doc in site.docs %}{% if doc.frontpage != false %}{% for hardware in doc.hardware %}{{ hardware }}|{% endfor %}{% endif %}{% endfor %}{% endcapture %}
 {% assign hwhash = hws | split:'|' | sort | tag_hash %}
 
   <div class="centre">


### PR DESCRIPTION
After archiving the v1 docs there are broken links on the Mime build page and some people still need to access them. This pull request reinstates the v1 docs but hides them from the front page. The front page looks exactly the same as currently but the links that went out with the original packaging will still point to the right place (http://mirobot.io/r/one) and so anyone trying to build an original v1 Mirobot still can.